### PR TITLE
cookie 重写增加对 ip 的支持

### DIFF
--- a/config.js
+++ b/config.js
@@ -23,7 +23,7 @@ const o={
         const cookie = proxyRes.headers['set-cookie'];
         if (cookie && cookie[0]){
             const host = req.headers['host'].split(':')[0];
-            cookie[0] = cookie[0].replace(/(domain=)\.([^\s;]+)/, '$1'+host);
+            cookie[0] = cookie[0].replace(/(domain=)(\.)?([^\s;]+)/, '$1'+host);
         }
     }
 }


### PR DESCRIPTION
你好，在使用这个工具的时候发现了一些问题
如果后端没有使用域名而是使用的 ip，这个 cookie 重写是不生效的，登录后会重新跳转到登录页
`cookie[0] = cookie[0].replace(/(domain=)\.([^\s;]+)/, '$1'+host);`
我修改了一下这个正则兼容掉 ip，修改后
`cookie[0] = cookie[0].replace(/(domain=)(\.)?([^\s;]+)/, '$1'+host);`

